### PR TITLE
Only half of MAX_RANGE can be measured

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl HcSr04 {
         // max range distance. In other words, if the timeout is reached, the measurement was not
         // successfull or the object is located too far away from the sensor in order to be
         // detected.
-        let timeout = Duration::from_secs_f32(MAX_RANGE / sound_speed);
+        let timeout = Duration::from_secs_f32(MAX_RANGE / sound_speed * 2.);
 
         (sound_speed, timeout)
     }


### PR DESCRIPTION
Thanks for the great work. I noticed that the MAX_RANGE is set to 4m, but it only measures a maximum of 2m. Since the sound is coming back and forth, the duration of timeout should be doubled. I hope this helps you.