### PR TITLE
Update rppal dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "distance"
 path = "examples/distance.rs"
 
 [dependencies]
-rppal = "0.14.1"
+rppal = "0.17.1"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Using the hc-sr04 library on a Raspberry pi zero 2 w isn't possible with the current version of rppal.

I think this somewhat related fix in v0.16 for recognizing Raspberry pi zero 2 also fixes my issue: https://github.com/golemparts/rppal/releases/tag/0.16.0
The fix was for Arch Linux but I'm running Ubuntu Server.