### PR TITLE
Fix blocked thread if echo high is not measured

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,12 +25,14 @@ use std::{
 pub enum Error {
     /// Occurs on Raspberry Pi GPIO error.
     Gpio(gpio::Error),
+    Timeout()
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             Self::Gpio(error) => write!(f, "GPIO error: {}", error),
+            Self::Timeout() => write!(f, "Timed out reading GPIO"),
         }
     }
 }


### PR DESCRIPTION
In some cases the measure_distance function may hang. I've noticed this when I place an object too close to the sensor (<2cm)